### PR TITLE
Removed permissions required by the Microsoft Intune Broker app, which w...

### DIFF
--- a/O365-Android-Start/app/src/main/AndroidManifest.xml
+++ b/O365-Android-Start/app/src/main/AndroidManifest.xml
@@ -8,11 +8,8 @@
         android:minSdkVersion="14"
         android:targetSdkVersion="20" />
 
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/O365-Android-Start/app/src/main/java/com/microsoft/office365/starter/O365APIsStart_Application.java
+++ b/O365-Android-Start/app/src/main/java/com/microsoft/office365/starter/O365APIsStart_Application.java
@@ -15,6 +15,7 @@ import android.widget.ArrayAdapter;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.discoveryservices.ServiceInfo;
 import com.microsoft.discoveryservices.odata.DiscoveryClient;
 import com.microsoft.office365.starter.helpers.AuthenticationController;
@@ -144,6 +145,15 @@ public class O365APIsStart_Application extends Application {
 
 		mDefaultUEH = Thread.getDefaultUncaughtExceptionHandler();
 		Thread.setDefaultUncaughtExceptionHandler(handler);
+
+
+		// We're not using Microsoft Intune's Company portal app,
+		// skip the broker check so we don't get warnings about the following permissions
+		// in manifest:
+		// GET_ACCOUNTS
+		// USE_CREDENTIALS
+		// MANAGE_ACCOUNTS
+		AuthenticationSettings.INSTANCE.setSkipBroker(true);
 	}
 
 


### PR DESCRIPTION
...e are not using. Added a call to AuthenticationSettings.INSTANCE.setSkipBroker(true) to prevent the following warning to show up in logcat:

DEVELOPER_BROKER_PERMISSIONS_MISSING: Broker related permissions are missing for GET_ACCOUNTS, MANAGE_ACCOUNTS, USE_CREDENTIALS ver:1.1.2
